### PR TITLE
Add support for super and varbyte columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Usage
 For Rails 7, write following in Gemfile:
 
 ```ruby
-gem 'activerecord7-redshift-adapter', git: 'https://github.com/pennylane-hq/activerecord7-redshift-adapter.git'
+git_source(:fork) { |name| "https://github.com/simplepractice/#{name}.git" }
+
+gem 'activerecord7-redshift-adapter', fork: 'activerecord7-redshift-adapter'
 ```
 
 In database.yml

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -41,11 +41,23 @@ module ActiveRecord
         end
 
         def json(name, **options)
-          column(name, :json, options)
+          column(name, :super, **options)
         end
 
         def jsonb(name, **options)
-          column(name, :jsonb, options)
+          column(name, :super, **options)
+        end
+
+        def binary(name, **options)
+          column(name, :varbyte, **options)
+        end
+
+        def text(name, **options)
+          unless options.has_key?(:limit)
+            options[:limit] = options[:size] == :tiny ? 255 : 65535
+          end
+
+          super
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -131,7 +131,7 @@ module ActiveRecord
         end
 
         def drop_table(table_name, **options)
-          execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
+          execute "DROP TABLE IF EXISTS #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
         end
 
         # Returns true if schema exists.

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -763,8 +763,8 @@ module ActiveRecord
         coder_class.new(oid: row['oid'].to_i, name: row['typname'])
       end
 
-      def create_table_definition(*args) # :nodoc:
-        Redshift::TableDefinition.new(self, *args)
+      def create_table_definition(name, **args) # :nodoc:
+        Redshift::TableDefinition.new(self, name, **args)
       end
     end
   end

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -359,6 +359,7 @@ module ActiveRecord
           m.alias_type 'timestamptz', 'timestamp'
           m.register_type 'date', Type::Date.new
           m.register_type 'time', Type::Time.new
+          m.register_type 'super', Type::Json.new
 
           m.register_type 'timestamp' do |_, _, sql_type|
             precision = extract_precision(sql_type)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183792469 (firechief)

* db:schema:load fails the first time because tables don't exist so errors out when it tries to drop them.
* The equivalent column type for json and jsonb is super and the equivalent to binary is varbyte.
* text columns have length 256 by default, but MySQL default is 65535.